### PR TITLE
Add document list endpoints

### DIFF
--- a/src/main/java/org/example/ktigerstudybe/controller/DocumentListController.java
+++ b/src/main/java/org/example/ktigerstudybe/controller/DocumentListController.java
@@ -1,4 +1,69 @@
 package org.example.ktigerstudybe.controller;
 
+import org.example.ktigerstudybe.dto.req.DocumentListRequest;
+import org.example.ktigerstudybe.dto.resp.DocumentListResponse;
+import org.example.ktigerstudybe.service.documentList.DocumentListService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/document-lists")
 public class DocumentListController {
+
+    @Autowired
+    private DocumentListService documentListService;
+
+    @PostMapping
+    public DocumentListResponse create(@RequestBody DocumentListRequest request) {
+        return documentListService.createDocumentList(request);
+    }
+
+    @GetMapping
+    public List<DocumentListResponse> getAll() {
+        return documentListService.getAllDocumentLists();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<DocumentListResponse> getById(@PathVariable Long id) {
+        try {
+            DocumentListResponse resp = documentListService.getDocumentListById(id);
+            return ResponseEntity.ok(resp);
+        } catch (Exception e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @GetMapping("/user/{userId}")
+    public List<DocumentListResponse> getByUser(@PathVariable Long userId) {
+        return documentListService.getDocumentListsByUserId(userId);
+    }
+
+    @GetMapping("/public")
+    public List<DocumentListResponse> getPublic() {
+        return documentListService.getPublicDocumentLists();
+    }
+
+    @GetMapping("/search")
+    public List<DocumentListResponse> search(@RequestParam String keyword) {
+        return documentListService.searchByTitle(keyword);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<DocumentListResponse> update(@PathVariable Long id, @RequestBody DocumentListRequest request) {
+        try {
+            DocumentListResponse resp = documentListService.updateDocumentList(id, request);
+            return ResponseEntity.ok(resp);
+        } catch (Exception e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        documentListService.deleteDocumentList(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/org/example/ktigerstudybe/dto/req/DocumentListRequest.java
+++ b/src/main/java/org/example/ktigerstudybe/dto/req/DocumentListRequest.java
@@ -1,0 +1,14 @@
+package org.example.ktigerstudybe.dto.req;
+
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+public class DocumentListRequest {
+    private Long userId;
+    private String title;
+    private String description;
+    private String type;
+    private LocalDateTime createdAt;
+    private int isPublic;
+}

--- a/src/main/java/org/example/ktigerstudybe/dto/resp/DocumentListResponse.java
+++ b/src/main/java/org/example/ktigerstudybe/dto/resp/DocumentListResponse.java
@@ -1,0 +1,15 @@
+package org.example.ktigerstudybe.dto.resp;
+
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+public class DocumentListResponse {
+    private Long listId;
+    private Long userId;
+    private String title;
+    private String description;
+    private String type;
+    private LocalDateTime createdAt;
+    private int isPublic;
+}

--- a/src/main/java/org/example/ktigerstudybe/service/documentList/DocumentListService.java
+++ b/src/main/java/org/example/ktigerstudybe/service/documentList/DocumentListService.java
@@ -1,33 +1,24 @@
 package org.example.ktigerstudybe.service.documentList;
 
-import org.example.ktigerstudybe.model.DocumentList;
+import org.example.ktigerstudybe.dto.req.DocumentListRequest;
+import org.example.ktigerstudybe.dto.resp.DocumentListResponse;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface DocumentListService {
+    DocumentListResponse createDocumentList(DocumentListRequest request);
 
-    // Tạo mới một danh sách tài liệu
-    DocumentList createDocumentList(DocumentList documentList);
+    List<DocumentListResponse> getAllDocumentLists();
 
-    // Lấy danh sách tất cả các DocumentList
-    List<DocumentList> getAllDocumentLists();
+    DocumentListResponse getDocumentListById(Long listId);
 
-    // Lấy DocumentList theo ID
-    Optional<DocumentList> getDocumentListById(Long listId);
+    DocumentListResponse updateDocumentList(Long listId, DocumentListRequest request);
 
-    // Cập nhật thông tin một DocumentList
-    DocumentList updateDocumentList(Long listId, DocumentList updatedDocumentList);
-
-    // Xóa một DocumentList theo ID
     void deleteDocumentList(Long listId);
 
-    // Lấy tất cả DocumentList của một User cụ thể
-    List<DocumentList> getDocumentListsByUserId(Long userId);
+    List<DocumentListResponse> getDocumentListsByUserId(Long userId);
 
-    // Lấy tất cả DocumentList công khai
-    List<DocumentList> getPublicDocumentLists();
+    List<DocumentListResponse> getPublicDocumentLists();
 
-    // Tìm kiếm theo tiêu đề chứa từ khóa
-    List<DocumentList> searchByTitle(String keyword);
+    List<DocumentListResponse> searchByTitle(String keyword);
 }

--- a/src/main/java/org/example/ktigerstudybe/service/documentList/DocumentListServiceImpl.java
+++ b/src/main/java/org/example/ktigerstudybe/service/documentList/DocumentListServiceImpl.java
@@ -1,51 +1,88 @@
 package org.example.ktigerstudybe.service.documentList;
 
+import org.example.ktigerstudybe.dto.req.DocumentListRequest;
+import org.example.ktigerstudybe.dto.resp.DocumentListResponse;
 import org.example.ktigerstudybe.model.DocumentList;
+import org.example.ktigerstudybe.model.User;
 import org.example.ktigerstudybe.repository.DocumentListRepository;
+import org.example.ktigerstudybe.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 public class DocumentListServiceImpl implements DocumentListService {
 
     private final DocumentListRepository documentListRepository;
+    private final UserRepository userRepository;
 
     @Autowired
-    public DocumentListServiceImpl(DocumentListRepository documentListRepository) {
+    public DocumentListServiceImpl(DocumentListRepository documentListRepository, UserRepository userRepository) {
         this.documentListRepository = documentListRepository;
+        this.userRepository = userRepository;
+    }
+
+    private DocumentListResponse toResponse(DocumentList doc) {
+        DocumentListResponse resp = new DocumentListResponse();
+        resp.setListId(doc.getListId());
+        resp.setUserId(doc.getUser().getUserId());
+        resp.setTitle(doc.getTitle());
+        resp.setDescription(doc.getDescription());
+        resp.setType(doc.getType());
+        resp.setCreatedAt(doc.getCreatedAt());
+        resp.setIsPublic(doc.getIsPublic());
+        return resp;
+    }
+
+    private DocumentList toEntity(DocumentListRequest req) {
+        DocumentList doc = new DocumentList();
+        User user = userRepository.findById(req.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + req.getUserId()));
+        doc.setUser(user);
+        doc.setTitle(req.getTitle());
+        doc.setDescription(req.getDescription());
+        doc.setType(req.getType());
+        doc.setCreatedAt(req.getCreatedAt());
+        doc.setIsPublic(req.getIsPublic());
+        return doc;
     }
 
     @Override
-    public DocumentList createDocumentList(DocumentList documentList) {
-        return documentListRepository.save(documentList);
+    public DocumentListResponse createDocumentList(DocumentListRequest request) {
+        DocumentList doc = toEntity(request);
+        doc = documentListRepository.save(doc);
+        return toResponse(doc);
     }
 
     @Override
-    public List<DocumentList> getAllDocumentLists() {
-        return (List<DocumentList>) documentListRepository.findAll();
+    public List<DocumentListResponse> getAllDocumentLists() {
+        return documentListRepository.findAll().stream()
+                .map(this::toResponse)
+                .toList();
     }
 
     @Override
-    public Optional<DocumentList> getDocumentListById(Long listId) {
-        return documentListRepository.findById(listId);
+    public DocumentListResponse getDocumentListById(Long listId) {
+        DocumentList doc = documentListRepository.findById(listId)
+                .orElseThrow(() -> new RuntimeException("DocumentList not found with ID: " + listId));
+        return toResponse(doc);
     }
 
     @Override
-    public DocumentList updateDocumentList(Long listId, DocumentList updatedDocumentList) {
-        return documentListRepository.findById(listId)
-            .map(existing -> {
-                existing.setTitle(updatedDocumentList.getTitle());
-                existing.setDescription(updatedDocumentList.getDescription());
-                existing.setType(updatedDocumentList.getType());
-                existing.setCreatedAt(updatedDocumentList.getCreatedAt());
-                existing.setIsPublic(updatedDocumentList.getIsPublic());
-                existing.setUser(updatedDocumentList.getUser());
-                return documentListRepository.save(existing);
-            })
-            .orElseThrow(() -> new RuntimeException("DocumentList not found with ID: " + listId));
+    public DocumentListResponse updateDocumentList(Long listId, DocumentListRequest request) {
+        DocumentList doc = documentListRepository.findById(listId)
+                .orElseThrow(() -> new RuntimeException("DocumentList not found with ID: " + listId));
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + request.getUserId()));
+        doc.setUser(user);
+        doc.setTitle(request.getTitle());
+        doc.setDescription(request.getDescription());
+        doc.setType(request.getType());
+        doc.setCreatedAt(request.getCreatedAt());
+        doc.setIsPublic(request.getIsPublic());
+        doc = documentListRepository.save(doc);
+        return toResponse(doc);
     }
 
     @Override
@@ -54,17 +91,23 @@ public class DocumentListServiceImpl implements DocumentListService {
     }
 
     @Override
-    public List<DocumentList> getDocumentListsByUserId(Long userId) {
-        return documentListRepository.findByUser_UserId(userId);
+    public List<DocumentListResponse> getDocumentListsByUserId(Long userId) {
+        return documentListRepository.findByUser_UserId(userId).stream()
+                .map(this::toResponse)
+                .toList();
     }
 
     @Override
-    public List<DocumentList> getPublicDocumentLists() {
-        return documentListRepository.findByIsPublic(1); // 1 nghĩa là public
+    public List<DocumentListResponse> getPublicDocumentLists() {
+        return documentListRepository.findByIsPublic(1).stream()
+                .map(this::toResponse)
+                .toList();
     }
 
     @Override
-    public List<DocumentList> searchByTitle(String keyword) {
-        return documentListRepository.findByTitleContainingIgnoreCase(keyword);
+    public List<DocumentListResponse> searchByTitle(String keyword) {
+        return documentListRepository.findByTitleContainingIgnoreCase(keyword).stream()
+                .map(this::toResponse)
+                .toList();
     }
 }


### PR DESCRIPTION
## Summary
- implement DocumentListRequest and DocumentListResponse DTOs
- refactor `DocumentListService` and `DocumentListServiceImpl` to use DTOs
- implement CRUD endpoints in `DocumentListController`

## Testing
- `./mvnw -q -DskipTests=false test` *(fails: unable to download Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68439df84e2083339c890f46e0be6851