### PR TITLE
Implement DocumentItem API

### DIFF
--- a/src/main/java/org/example/ktigerstudybe/controller/DocumentItemController.java
+++ b/src/main/java/org/example/ktigerstudybe/controller/DocumentItemController.java
@@ -1,0 +1,60 @@
+package org.example.ktigerstudybe.controller;
+
+import org.example.ktigerstudybe.dto.req.DocumentItemRequest;
+import org.example.ktigerstudybe.dto.resp.DocumentItemResponse;
+import org.example.ktigerstudybe.service.documentItem.DocumentItemService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/document-items")
+public class DocumentItemController {
+
+    @Autowired
+    private DocumentItemService documentItemService;
+
+    @PostMapping
+    public DocumentItemResponse create(@RequestBody DocumentItemRequest request) {
+        return documentItemService.createDocumentItem(request);
+    }
+
+    @GetMapping
+    public List<DocumentItemResponse> getAll() {
+        return documentItemService.getAllDocumentItems();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<DocumentItemResponse> getById(@PathVariable Long id) {
+        try {
+            DocumentItemResponse resp = documentItemService.getDocumentItemById(id);
+            return ResponseEntity.ok(resp);
+        } catch (Exception e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @GetMapping("/list/{listId}")
+    public List<DocumentItemResponse> getByList(@PathVariable Long listId) {
+        return documentItemService.getDocumentItemsByListId(listId);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<DocumentItemResponse> update(@PathVariable Long id, @RequestBody DocumentItemRequest request) {
+        try {
+            DocumentItemResponse resp = documentItemService.updateDocumentItem(id, request);
+            return ResponseEntity.ok(resp);
+        } catch (Exception e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        documentItemService.deleteDocumentItem(id);
+        return ResponseEntity.noContent().build();
+    }
+}
+

--- a/src/main/java/org/example/ktigerstudybe/dto/req/DocumentItemRequest.java
+++ b/src/main/java/org/example/ktigerstudybe/dto/req/DocumentItemRequest.java
@@ -1,0 +1,12 @@
+package org.example.ktigerstudybe.dto.req;
+
+import lombok.Data;
+
+@Data
+public class DocumentItemRequest {
+    private Long listId;
+    private String word;
+    private String meaning;
+    private String example;
+    private String vocabImage;
+}

--- a/src/main/java/org/example/ktigerstudybe/dto/resp/DocumentItemResponse.java
+++ b/src/main/java/org/example/ktigerstudybe/dto/resp/DocumentItemResponse.java
@@ -1,0 +1,13 @@
+package org.example.ktigerstudybe.dto.resp;
+
+import lombok.Data;
+
+@Data
+public class DocumentItemResponse {
+    private Long wordId;
+    private Long listId;
+    private String word;
+    private String meaning;
+    private String example;
+    private String vocabImage;
+}

--- a/src/main/java/org/example/ktigerstudybe/model/DocumentItem.java
+++ b/src/main/java/org/example/ktigerstudybe/model/DocumentItem.java
@@ -1,0 +1,34 @@
+package org.example.ktigerstudybe.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "document_item")
+public class DocumentItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "WordID")
+    private Long wordId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ListID", nullable = false)
+    private DocumentList documentList;
+
+    @Column(name = "Word")
+    private String word;
+
+    @Column(name = "Meaning")
+    private String meaning;
+
+    @Column(name = "Example")
+    private String example;
+
+    @Column(name = "VocabImage")
+    private String vocabImage;
+}
+

--- a/src/main/java/org/example/ktigerstudybe/model/DocumentList.java
+++ b/src/main/java/org/example/ktigerstudybe/model/DocumentList.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+import org.example.ktigerstudybe.model.DocumentItem;
 import java.time.LocalDateTime;
 
 @Getter
@@ -35,6 +37,8 @@ public class DocumentList {
 
     @Column(name = "IsPublic")
     private int isPublic;
+    @OneToMany(mappedBy = "documentList", cascade = CascadeType.ALL)
+    private List<DocumentItem> items;
 
 
 }

--- a/src/main/java/org/example/ktigerstudybe/repository/DocumentItemRepository.java
+++ b/src/main/java/org/example/ktigerstudybe/repository/DocumentItemRepository.java
@@ -1,0 +1,10 @@
+package org.example.ktigerstudybe.repository;
+
+import org.example.ktigerstudybe.model.DocumentItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DocumentItemRepository extends JpaRepository<DocumentItem, Long> {
+    List<DocumentItem> findByDocumentList_ListId(Long listId);
+}

--- a/src/main/java/org/example/ktigerstudybe/service/documentItem/DocumentItemService.java
+++ b/src/main/java/org/example/ktigerstudybe/service/documentItem/DocumentItemService.java
@@ -1,0 +1,16 @@
+package org.example.ktigerstudybe.service.documentItem;
+
+import org.example.ktigerstudybe.dto.req.DocumentItemRequest;
+import org.example.ktigerstudybe.dto.resp.DocumentItemResponse;
+
+import java.util.List;
+
+public interface DocumentItemService {
+    DocumentItemResponse createDocumentItem(DocumentItemRequest request);
+    List<DocumentItemResponse> getAllDocumentItems();
+    DocumentItemResponse getDocumentItemById(Long id);
+    List<DocumentItemResponse> getDocumentItemsByListId(Long listId);
+    DocumentItemResponse updateDocumentItem(Long id, DocumentItemRequest request);
+    void deleteDocumentItem(Long id);
+}
+

--- a/src/main/java/org/example/ktigerstudybe/service/documentItem/DocumentItemServiceImpl.java
+++ b/src/main/java/org/example/ktigerstudybe/service/documentItem/DocumentItemServiceImpl.java
@@ -1,0 +1,95 @@
+package org.example.ktigerstudybe.service.documentItem;
+
+import org.example.ktigerstudybe.dto.req.DocumentItemRequest;
+import org.example.ktigerstudybe.dto.resp.DocumentItemResponse;
+import org.example.ktigerstudybe.model.DocumentItem;
+import org.example.ktigerstudybe.model.DocumentList;
+import org.example.ktigerstudybe.repository.DocumentItemRepository;
+import org.example.ktigerstudybe.repository.DocumentListRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class DocumentItemServiceImpl implements DocumentItemService {
+
+    @Autowired
+    private DocumentItemRepository documentItemRepository;
+
+    @Autowired
+    private DocumentListRepository documentListRepository;
+
+    private DocumentItemResponse toResponse(DocumentItem item) {
+        DocumentItemResponse resp = new DocumentItemResponse();
+        resp.setWordId(item.getWordId());
+        resp.setListId(item.getDocumentList().getListId());
+        resp.setWord(item.getWord());
+        resp.setMeaning(item.getMeaning());
+        resp.setExample(item.getExample());
+        resp.setVocabImage(item.getVocabImage());
+        return resp;
+    }
+
+    private DocumentItem toEntity(DocumentItemRequest req) {
+        DocumentItem item = new DocumentItem();
+        DocumentList list = documentListRepository.findById(req.getListId())
+                .orElseThrow(() -> new IllegalArgumentException("DocumentList not found with id: " + req.getListId()));
+        item.setDocumentList(list);
+        item.setWord(req.getWord());
+        item.setMeaning(req.getMeaning());
+        item.setExample(req.getExample());
+        item.setVocabImage(req.getVocabImage());
+        return item;
+    }
+
+    @Override
+    public DocumentItemResponse createDocumentItem(DocumentItemRequest request) {
+        DocumentItem item = toEntity(request);
+        item = documentItemRepository.save(item);
+        return toResponse(item);
+    }
+
+    @Override
+    public List<DocumentItemResponse> getAllDocumentItems() {
+        return documentItemRepository.findAll().stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public DocumentItemResponse getDocumentItemById(Long id) {
+        DocumentItem item = documentItemRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("DocumentItem not found with id: " + id));
+        return toResponse(item);
+    }
+
+    @Override
+    public List<DocumentItemResponse> getDocumentItemsByListId(Long listId) {
+        return documentItemRepository.findByDocumentList_ListId(listId).stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public DocumentItemResponse updateDocumentItem(Long id, DocumentItemRequest request) {
+        DocumentItem item = documentItemRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("DocumentItem not found with id: " + id));
+        DocumentList list = documentListRepository.findById(request.getListId())
+                .orElseThrow(() -> new IllegalArgumentException("DocumentList not found with id: " + request.getListId()));
+        item.setDocumentList(list);
+        item.setWord(request.getWord());
+        item.setMeaning(request.getMeaning());
+        item.setExample(request.getExample());
+        item.setVocabImage(request.getVocabImage());
+        item = documentItemRepository.save(item);
+        return toResponse(item);
+    }
+
+    @Override
+    public void deleteDocumentItem(Long id) {
+        documentItemRepository.deleteById(id);
+    }
+}
+


### PR DESCRIPTION
## Summary
- model and repository for `DocumentItem`
- service layer for creating and managing document items
- controller with CRUD endpoints
- request/response DTOs
- add list of `DocumentItem` in `DocumentList`

## Testing
- `./mvnw -q test` *(fails: could not download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6843a4c63f208333b5c259f732658a42