### PR TITLE
Implement admin utility endpoints

### DIFF
--- a/src/main/java/org/example/ktigerstudybe/controller/DocumentReportController.java
+++ b/src/main/java/org/example/ktigerstudybe/controller/DocumentReportController.java
@@ -1,0 +1,27 @@
+package org.example.ktigerstudybe.controller;
+
+import org.example.ktigerstudybe.dto.req.DocumentReportRequest;
+import org.example.ktigerstudybe.dto.resp.DocumentReportResponse;
+import org.example.ktigerstudybe.service.documentReport.DocumentReportService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/document-reports")
+public class DocumentReportController {
+
+    @Autowired
+    private DocumentReportService documentReportService;
+
+    @PostMapping
+    public DocumentReportResponse create(@RequestBody DocumentReportRequest request) {
+        return documentReportService.createDocumentReport(request);
+    }
+
+    @GetMapping
+    public List<DocumentReportResponse> getAll() {
+        return documentReportService.getAllReports();
+    }
+}

--- a/src/main/java/org/example/ktigerstudybe/controller/StatisticsController.java
+++ b/src/main/java/org/example/ktigerstudybe/controller/StatisticsController.java
@@ -1,0 +1,21 @@
+package org.example.ktigerstudybe.controller;
+
+import org.example.ktigerstudybe.dto.resp.StatisticsResponse;
+import org.example.ktigerstudybe.service.stats.StatisticsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/statistics")
+public class StatisticsController {
+
+    @Autowired
+    private StatisticsService statisticsService;
+
+    @GetMapping
+    public StatisticsResponse getStatistics() {
+        return statisticsService.getStatistics();
+    }
+}

--- a/src/main/java/org/example/ktigerstudybe/controller/UserController.java
+++ b/src/main/java/org/example/ktigerstudybe/controller/UserController.java
@@ -52,4 +52,29 @@ public class UserController {
     userService.deleteUser(id);
     return ResponseEntity.noContent().build();
   }
+
+  @PostMapping("/{id}/freeze")
+  public ResponseEntity<UserResponse> freezeUser(@PathVariable Long id) {
+    try {
+      UserResponse resp = userService.freezeUser(id);
+      return ResponseEntity.ok(resp);
+    } catch (Exception e) {
+      return ResponseEntity.notFound().build();
+    }
+  }
+
+  @PostMapping("/{id}/unfreeze")
+  public ResponseEntity<UserResponse> unfreezeUser(@PathVariable Long id) {
+    try {
+      UserResponse resp = userService.unfreezeUser(id);
+      return ResponseEntity.ok(resp);
+    } catch (Exception e) {
+      return ResponseEntity.notFound().build();
+    }
+  }
+
+  @GetMapping("/search")
+  public List<UserResponse> searchUsers(@RequestParam String keyword) {
+    return userService.searchUsers(keyword);
+  }
 }

--- a/src/main/java/org/example/ktigerstudybe/dto/req/DocumentReportRequest.java
+++ b/src/main/java/org/example/ktigerstudybe/dto/req/DocumentReportRequest.java
@@ -1,0 +1,12 @@
+package org.example.ktigerstudybe.dto.req;
+
+import lombok.Data;
+import java.time.LocalDate;
+
+@Data
+public class DocumentReportRequest {
+    private Long userId;
+    private Long listId;
+    private String reason;
+    private LocalDate reportDate;
+}

--- a/src/main/java/org/example/ktigerstudybe/dto/resp/DocumentReportResponse.java
+++ b/src/main/java/org/example/ktigerstudybe/dto/resp/DocumentReportResponse.java
@@ -1,0 +1,13 @@
+package org.example.ktigerstudybe.dto.resp;
+
+import lombok.Data;
+import java.time.LocalDate;
+
+@Data
+public class DocumentReportResponse {
+    private Long reportId;
+    private Long userId;
+    private Long listId;
+    private String reason;
+    private LocalDate reportDate;
+}

--- a/src/main/java/org/example/ktigerstudybe/dto/resp/StatisticsResponse.java
+++ b/src/main/java/org/example/ktigerstudybe/dto/resp/StatisticsResponse.java
@@ -1,0 +1,10 @@
+package org.example.ktigerstudybe.dto.resp;
+
+import lombok.Data;
+
+@Data
+public class StatisticsResponse {
+    private long totalUsers;
+    private long frozenUsers;
+    private long newUsers;
+}

--- a/src/main/java/org/example/ktigerstudybe/repository/UserRepository.java
+++ b/src/main/java/org/example/ktigerstudybe/repository/UserRepository.java
@@ -2,7 +2,14 @@ package org.example.ktigerstudybe.repository;
 
 import org.example.ktigerstudybe.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    // Search users by name, email or username
+    List<User> findByFullNameContainingIgnoreCaseOrEmailContainingIgnoreCaseOrUserNameContainingIgnoreCase(
+            String fullName, String email, String userName);
 
+    long countByUserStatus(int status);
+
+    long countByJoinDateAfter(java.time.LocalDate date);
 }

--- a/src/main/java/org/example/ktigerstudybe/service/documentReport/DocumentReportService.java
+++ b/src/main/java/org/example/ktigerstudybe/service/documentReport/DocumentReportService.java
@@ -1,0 +1,11 @@
+package org.example.ktigerstudybe.service.documentReport;
+
+import org.example.ktigerstudybe.dto.req.DocumentReportRequest;
+import org.example.ktigerstudybe.dto.resp.DocumentReportResponse;
+
+import java.util.List;
+
+public interface DocumentReportService {
+    DocumentReportResponse createDocumentReport(DocumentReportRequest request);
+    List<DocumentReportResponse> getAllReports();
+}

--- a/src/main/java/org/example/ktigerstudybe/service/documentReport/DocumentReportServiceImpl.java
+++ b/src/main/java/org/example/ktigerstudybe/service/documentReport/DocumentReportServiceImpl.java
@@ -1,0 +1,65 @@
+package org.example.ktigerstudybe.service.documentReport;
+
+import org.example.ktigerstudybe.dto.req.DocumentReportRequest;
+import org.example.ktigerstudybe.dto.resp.DocumentReportResponse;
+import org.example.ktigerstudybe.model.DocumentList;
+import org.example.ktigerstudybe.model.DocumentReport;
+import org.example.ktigerstudybe.model.User;
+import org.example.ktigerstudybe.repository.DocumentListRepository;
+import org.example.ktigerstudybe.repository.DocumentReportRepository;
+import org.example.ktigerstudybe.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class DocumentReportServiceImpl implements DocumentReportService {
+
+    @Autowired
+    private DocumentReportRepository documentReportRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private DocumentListRepository documentListRepository;
+
+    private DocumentReportResponse toResponse(DocumentReport report) {
+        DocumentReportResponse resp = new DocumentReportResponse();
+        resp.setReportId(report.getReportId());
+        resp.setUserId(report.getUser().getUserId());
+        resp.setListId(report.getDocumentList().getListId());
+        resp.setReason(report.getReason());
+        resp.setReportDate(report.getReportDate());
+        return resp;
+    }
+
+    private DocumentReport toEntity(DocumentReportRequest req) {
+        DocumentReport report = new DocumentReport();
+        User user = userRepository.findById(req.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + req.getUserId()));
+        DocumentList list = documentListRepository.findById(req.getListId())
+                .orElseThrow(() -> new IllegalArgumentException("DocumentList not found with id: " + req.getListId()));
+        report.setUser(user);
+        report.setDocumentList(list);
+        report.setReason(req.getReason());
+        report.setReportDate(req.getReportDate());
+        return report;
+    }
+
+    @Override
+    public DocumentReportResponse createDocumentReport(DocumentReportRequest request) {
+        DocumentReport report = toEntity(request);
+        report = documentReportRepository.save(report);
+        return toResponse(report);
+    }
+
+    @Override
+    public List<DocumentReportResponse> getAllReports() {
+        return documentReportRepository.findAll().stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/example/ktigerstudybe/service/stats/StatisticsService.java
+++ b/src/main/java/org/example/ktigerstudybe/service/stats/StatisticsService.java
@@ -1,0 +1,7 @@
+package org.example.ktigerstudybe.service.stats;
+
+import org.example.ktigerstudybe.dto.resp.StatisticsResponse;
+
+public interface StatisticsService {
+    StatisticsResponse getStatistics();
+}

--- a/src/main/java/org/example/ktigerstudybe/service/stats/StatisticsServiceImpl.java
+++ b/src/main/java/org/example/ktigerstudybe/service/stats/StatisticsServiceImpl.java
@@ -1,0 +1,24 @@
+package org.example.ktigerstudybe.service.stats;
+
+import org.example.ktigerstudybe.dto.resp.StatisticsResponse;
+import org.example.ktigerstudybe.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+public class StatisticsServiceImpl implements StatisticsService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public StatisticsResponse getStatistics() {
+        StatisticsResponse resp = new StatisticsResponse();
+        resp.setTotalUsers(userRepository.count());
+        resp.setFrozenUsers(userRepository.countByUserStatus(1));
+        resp.setNewUsers(userRepository.countByJoinDateAfter(LocalDate.now().minusDays(7)));
+        return resp;
+    }
+}

--- a/src/main/java/org/example/ktigerstudybe/service/user/UserService.java
+++ b/src/main/java/org/example/ktigerstudybe/service/user/UserService.java
@@ -6,9 +6,15 @@ import org.example.ktigerstudybe.dto.resp.UserResponse;
 import java.util.List;
 
 public interface UserService {
-	List<UserResponse> getAllUsers();
-	UserResponse getUserById(Long id);
-	UserResponse createUser(UserRequest request);
-	UserResponse updateUser(Long id, UserRequest request);
-	void deleteUser(Long id);
+        List<UserResponse> getAllUsers();
+        UserResponse getUserById(Long id);
+        UserResponse createUser(UserRequest request);
+        UserResponse updateUser(Long id, UserRequest request);
+        void deleteUser(Long id);
+
+        UserResponse freezeUser(Long id);
+
+        UserResponse unfreezeUser(Long id);
+
+        List<UserResponse> searchUsers(String keyword);
 }

--- a/src/main/java/org/example/ktigerstudybe/service/user/UserServiceImpl.java
+++ b/src/main/java/org/example/ktigerstudybe/service/user/UserServiceImpl.java
@@ -90,4 +90,32 @@ public class UserServiceImpl implements UserService {
   public void deleteUser(Long id) {
     userRepository.deleteById(id);
   }
+
+  @Override
+  public UserResponse freezeUser(Long id) {
+    User user = userRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + id));
+    user.setUserStatus(1);
+    user = userRepository.save(user);
+    return toResponse(user);
+  }
+
+  @Override
+  public UserResponse unfreezeUser(Long id) {
+    User user = userRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + id));
+    user.setUserStatus(0);
+    user = userRepository.save(user);
+    return toResponse(user);
+  }
+
+  @Override
+  public List<UserResponse> searchUsers(String keyword) {
+    return userRepository
+            .findByFullNameContainingIgnoreCaseOrEmailContainingIgnoreCaseOrUserNameContainingIgnoreCase(
+                    keyword, keyword, keyword)
+            .stream()
+            .map(this::toResponse)
+            .collect(Collectors.toList());
+  }
 }


### PR DESCRIPTION
## Summary
- add request/response DTOs for document reports and statistics
- support freeze/unfreeze and search on users
- provide controllers and services for document reports and statistics

## Testing
- `mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_68464b4055ac8333a784dfdb1480b8ec